### PR TITLE
Add some Gmake files for building the tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all:
+	cd tools && $(MAKE) $@
+
+install: dummy
+	cd tools && $(MAKE) $@
+
+clean:
+	cd tools && $(MAKE) $@
+
+dummy:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,21 @@
+CC?=		gcc
+CFLAGS?=	-O2 -Wall
+LDFLAGS?=	-lpcap -lm
+PROGS?=		flow6 frag6 icmp6 jumbo6 na6 ni6 ns6 ra6 rd6 rs6 scan6 tcp6
+PREFIX?=	/usr
+INSTALL_BIN?=	${PREFIX}/bin
+INSTALL?=	cp -p
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+all: ${PROGS}
+
+clean:
+	rm -f ${PROGS}
+
+install: all
+	mkdir -p $(INSTALL_BIN)
+	${INSTALL} ${PROGS} ${INSTALL_BIN}
+
+.PHONY: clean install


### PR DESCRIPTION
This makes building the tools a bit easier.

gmake will select "GNUmakefile" by default, so a simple call to "make" or "make all" will build all the tools.

If there's no interest in supporting bmake scripts, these can be renamed to more familiar "Makefile" name.
