### PR TITLE
Fix segmentation fault in icmp6.c

### DIFF
--- a/tools/icmp6.c
+++ b/tools/icmp6.c
@@ -1067,7 +1067,7 @@ int main(int argc, char **argv){
 		}
 	}
 
-	if( (idata.type = pcap_datalink(idata.pd)) == DLT_EN10MB){
+	if( (idata.type = pcap_datalink(pfd)) == DLT_EN10MB){
 		linkhsize= ETH_HLEN;
 		idata.mtu= ETH_DATA_LEN;
 	}


### PR DESCRIPTION
icmp6 currently segfaults at startup because pcap_datalink() is called on idata.pd (which is NULL) instead of pfd. This commit fixes it.
