### PR TITLE
Changing binary location to /usr/sbin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFLAGS= -Wall
 LDFLAGS+= -lpcap -lm
 MANPATH= /usr/share/man
 DATAPATH= /usr/share
-BINPATH= /usr/bin
+BINPATH= /usr/sbin
 SRCPATH= tools
 TOOLS= flow6 frag6 icmp6 jumbo6 na6 ni6 ns6 ra6 rd6 rs6 scan6 tcp6
 


### PR DESCRIPTION
It should be more safe to install the binaries to /usr/sbin
