### PR TITLE
manpages: fix dashes as hyphens as detected by lintian

### DIFF
--- a/manuals/icmp6.1
+++ b/manuals/icmp6.1
@@ -23,7 +23,7 @@ The icmp6 tool supports IPv6 fragmentation, which might be of use to circumvent 
 
 .TP
 .BI \-i\  INTERFACE ,\ \-\-interface\  INTERFACE
-This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
+This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("\-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
 
 .TP
 .BI \-s\  SRC_ADDR ,\ \-\-src\-address\  SRC_ADDR

--- a/manuals/na6.1
+++ b/manuals/na6.1
@@ -23,7 +23,7 @@ Depending on the amount of information (i.e., options) to be conveyed into the N
 
 .TP
 .BI \-i\  INTERFACE ,\ \-\-interface\  INTERFACE
-This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
+This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("\-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
 
 .TP
 .BI \-s\  SRC_ADDR ,\ \-\-src\-address\  SRC_ADDR

--- a/manuals/ni6.1
+++ b/manuals/ni6.1
@@ -23,7 +23,7 @@ ni6 supports IPv6 Extension Headers, including the IPv6 Fragmentation Header, wh
 
 .TP
 .BI \-i\  INTERFACE ,\ \-\-interface\  INTERFACE
-This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
+This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("\-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
 
 .TP
 .BI \-s\  SRC_ADDR ,\ \-\-src\-address\  SRC_ADDR

--- a/manuals/ra6.1
+++ b/manuals/ra6.1
@@ -23,7 +23,7 @@ The tool supports filtering of incoming Router Solicitation messages based on th
 
 .TP
 .BI \-i\  INTERFACE ,\ \-\-interface\  INTERFACE
-This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
+This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("\-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
 
 .TP
 .BI \-s\  SRC_ADDR ,\ \-\-src\-address\  SRC_ADDR

--- a/manuals/rd6.1
+++ b/manuals/rd6.1
@@ -23,7 +23,7 @@ Depending on the amount of information (i.e., options) to be conveyed into the I
 
 .TP
 .BI \-i\  INTERFACE ,\ \-\-interface\  INTERFACE
-This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
+This option specifies the network interface that the tool will use. If the destination address ("\-d" option) is a link-local address, or the "listening" ("\-L") mode is selected, the interface must be explicitly specified. The interface may also be specified along with a destination address, with the "\-d" option.
 
 .TP
 .BI \-s\  SRC_ADDR ,\ \-\-src\-address\  SRC_ADDR


### PR DESCRIPTION
In an experimental Debian package I created lintian threw these manpage warnings regarding misuse of the hyphen symbol. This fixes it to change them back to dashes, as they were originally intended to be.
