### PR TITLE
struct in6_addr member .s6_addr16  is non-standard! Start replacing it with .s6_addr.

### DIFF
--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -629,15 +629,21 @@ int ether_ntop(const struct ether_addr *ether, char *ascii, size_t s){
 
 void ether_to_ipv6_linklocal(struct ether_addr *etheraddr, struct in6_addr *ipv6addr){
 	unsigned int i;
-	ipv6addr->s6_addr16[0]= htons(0xfe80); /* Link-local unicast prefix */
+	ipv6addr->s6_addr[0] = 0xfe; /* Link-local unicast prefix */
+	ipv6addr->s6_addr[1] = 0x80;
 
-	for(i=1;i<4;i++)
-		ipv6addr->s6_addr16[i]=0x0000;
+	for(i=2;i<8;i++)
+		ipv6addr->s6_addr[i]=0x00;
 
-	ipv6addr->s6_addr16[4]=  htons(((u_int16_t)etheraddr->a[0] << 8) | etheraddr->a[1]);
-	ipv6addr->s6_addr16[5]=  htons( ((u_int16_t)etheraddr->a[2] << 8) | 0xff);
-	ipv6addr->s6_addr16[6]=  htons((u_int16_t) 0xfe00 | etheraddr->a[3]);
-	ipv6addr->s6_addr16[7]=  htons(((u_int16_t)etheraddr->a[4] << 8) | etheraddr->a[5]);
+	ipv6addr->s6_addr[9]=  etheraddr->a[0];
+	ipv6addr->s6_addr[10]=  etheraddr->a[1];
+	ipv6addr->s6_addr[11]=  etheraddr->a[2];
+	ipv6addr->s6_addr[12]=  0xff;
+	ipv6addr->s6_addr[13]=  0xfe;
+	ipv6addr->s6_addr[14]=  etheraddr->a[3];
+	ipv6addr->s6_addr[15]=  etheraddr->a[4];
+	ipv6addr->s6_addr[16]=  etheraddr->a[5];
+
 }
 
 


### PR DESCRIPTION
Disclaimer: this patch was only tested for project building. Functional tests were not made.

libipv6.c: replace usage of struct in6_addr.s6_addr16 with .s6_addr.

struct in6_addr.s6_addr16 is not standard [1]. The only standard member of
this structure is uint8_t s6_addr[16].

[1] netinet/in.h - Internet address family
    http://pubs.opengroup.org/onlinepubs/009695299/basedefs/netinet/in.h.html

There are 289 more instances of the usage of s6_addr16 that need to be fixed. I suggest further programming no longer uses this non-standard structure member.

Also, there are 16 instances of s6_addr32, and s6_addr8 is declared although not used. Those will need to be fixed too. Again, I suggest further development refrains from using s6_addr(8|16|32) and limit its usage to s6_addr.

This patch series just sets the bar on what the goal is, and provides the first two changes to set the reference for everybody else.
