### PR TITLE
Lintian fix: remove bad newline in manpage script6.1

### DIFF
--- a/manuals/script6.1
+++ b/manuals/script6.1
@@ -225,7 +225,7 @@ The resulting output will have the following syntax:
 .sp
 .RS 4
 .nf
-    DEST#LAST_NOEH#HOPS_NOEH#LAST_EH$HOPS_EH#DROPN#DROPN2\n
+    DEST#LAST_NOEH#HOPS_NOEH#LAST_EH$HOPS_EH#DROPN#DROPN2
 .fi
 .RE
 


### PR DESCRIPTION
Debian reported the following warning. This is a fix for it.
