### PR TITLE
update perl shebang to be more cross-platform

### DIFF
--- a/tools/blackhole6
+++ b/tools/blackhole6
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # blackhole6: A tool to make complex IPv6 tasks easy
 #

--- a/tools/messi
+++ b/tools/messi
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Puedo especificar dos cosas:
 # 1) Hints: Direcciones y/o dominios

--- a/tools/script6
+++ b/tools/script6
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 #
 # script6: A tool to make complex IPv6 tasks easy
 #


### PR DESCRIPTION
Just a tiny change that uses `env` in the 3 perl tools/scripts, which makes it work when you have your preferred version of perl in `/usr/local/bin` for example.