### PR TITLE
Do not set RTA_IFP in routing message header.

### DIFF
--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -2854,7 +2854,7 @@ int sel_next_hop(struct iface_data *idata){
 		rtm->rtm_msglen= sizeof(struct rt_msghdr) + sizeof(struct sockaddr_in6);
 		rtm->rtm_version= RTM_VERSION;
 		rtm->rtm_type= RTM_GET;
-		rtm->rtm_addrs= RTA_DST | RTA_IFP;
+		rtm->rtm_addrs= RTA_DST;
 		rtm->rtm_pid= pid= getpid();
 		rtm->rtm_seq= seq= random();
 


### PR DESCRIPTION
sel_next_hop() sets the address field to RTA_DST and RTA_IFP in the
routing header, but only provides the RTA_DST socket address.  A
stricter check in the OpenBSD kernel detects this inconsistency and
rejects the routing message with EINVAL.  So set only RTA_DST.