### PR TITLE
update PCAP_TIMEOUT to 1, so Kali is able to scan again

### DIFF
--- a/tools/libipv6.h
+++ b/tools/libipv6.h
@@ -123,11 +123,7 @@ struct filters{
 	#define PCAP_NETMASK_UNKNOWN	0xffffffff
 #endif
 
-#if defined (__FreeBSD__) || defined(__NetBSD__) || defined (__OpenBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) || defined(sun) || defined(__sun)
-	#define	PCAP_TIMEOUT			1
-#else
-	#define	PCAP_TIMEOUT			0
-#endif
+#define	PCAP_TIMEOUT			1
 
 
 #define PCAP_IPV6_FILTER		"ip6"


### PR DESCRIPTION
I came across this problem by testing the tool on an (currently) up to date Kali. The programm runs fine without any error messages, but still does not find any devices on the network.

After a few hours I eventually found out, that the function `pcap_next_ex` never returned a packet, even if Wireshark (or tcpdump) showed one incoming. Changing the pcap timeout to 1 solved the problem.

I suspect this might be an issue because with timeout 0 the operating system waits until the buffer is filled up. Therefore, on a system with very little network traffic (e.g. a Kali doing only a litte scan) the buffer fills not up until the timeout implemented in the scan tool directly is reached, meaning that the scan tool does not receive any packets in this time, thus finding no hosts at all.

This fix is not very sophisticated and could cause problems with other operating systems. I am not sure why the differentiation between different OSes was made in the first place.

Additionally to Kali, I tested this patch with Ubuntu 18.04LTS.

Issue #40 could be related. (But I am not sure, whats the exact problem there)