### PR TITLE
Fix address randomization where prefix and output buffer are equal

### DIFF
--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -1816,9 +1816,12 @@ void randomize_ether_addr(struct ether_addr *ethaddr){
  * randomize_ipv6_addr()
  *
  * Select a random IPv6 from a given prefix.
+ *
+ * Caller needs to ensure that @prefix is zeroed (bitwise) beyond preflen.
  */
 
 void randomize_ipv6_addr(struct in6_addr *ipv6addr, struct in6_addr *prefix, uint8_t preflen){
+	const struct in6_addr prefix_cpy = *prefix;
 	uint32_t mask;
 	uint8_t startrand;	
 	unsigned int i;
@@ -1841,9 +1844,9 @@ void randomize_ipv6_addr(struct in6_addr *ipv6addr, struct in6_addr *prefix, uin
 		ipv6addr->s6_addr32[startrand]= ipv6addr->s6_addr32[startrand] & htonl(mask);
 	}
 
-	for(i=0; i<=(preflen/32); i++)
-		ipv6addr->s6_addr32[i]= ipv6addr->s6_addr32[i] | prefix->s6_addr32[i];
-
+	for(i=0; i<=(preflen/32); i++) {
+		ipv6addr->s6_addr32[i]= ipv6addr->s6_addr32[i] | prefix_cpy.s6_addr32[i];
+	}
 }
 
 


### PR DESCRIPTION
Various callers of randomize_ipv6_addr() use the same buffer for the
passed prefix and the output buffer are the same. When they do, the
prefix in the output buffer is all zeroes instead of the given prefix
after randomize_ipv6_addr().

Unfortunately, randomize_ipv6_addr() partially zeroes the output buffer
before reading the prefix. This leads to an IPv6 source address of
"::\<random-iface-id\>" instead of "fe80::\<random-iface-id\>" when invoking
"$ ns6 -i \<iface\>" (so when invoked without an explicit "-s" option).

Fixing this by creating a copy of the prefix buffer before starting to
modify the output (and by that potentially the original prefix) buffer.

It seems that this issue was fixed once before here:

    1cb91c4 ("Miscellaneous fixes and initial ESP/AH support for path6, blackhole6, and script6")

But got reintroduced to fix a different issue:

    8accda8 ("Fix issue in address randomization")

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>