### PR TITLE
Fix IPv6 link-local multicast destination addresses

### DIFF
--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -3615,7 +3615,9 @@ int load_dst_and_pcap(struct iface_data *idata, unsigned int mode){
 	unsigned char		randpreflen;
 	char				errbuf[PCAP_ERRBUF_SIZE];
 
-	if(mode != LOAD_PCAP_ONLY && IN6_IS_ADDR_LINKLOCAL(&(idata->dstaddr))){
+	if(mode != LOAD_PCAP_ONLY &&
+	   (IN6_IS_ADDR_LINKLOCAL(&(idata->dstaddr)) ||
+	    IN6_IS_ADDR_MC_LINKLOCAL(&(idata->dstaddr)))) {
 		/* Special case where the Destination Address is a link-local address */
 		if(!idata->iface_f){
 			puts("Need to specify an interface ('-i' option) when Destination Address is link-local");


### PR DESCRIPTION
Similarly to link-local unicast addresses, link-local multicast
addresses are tied to a specific interface, too. And don't need any
prior Neighbor Discovery address lookup.

This fixes using an invocation like "$ rs6 -i eth0 -d ff12::123"
for example. Next to rs6, all other tools using
load_dst_and_pcap(&idata, mode) with mode != LOAD_PCAP_ONLY are
likely affected.

Routable multicast addresses are untested so far.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>