### PR TITLE
Fix strncpy(): len must include null byte

### DIFF
--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -3557,7 +3557,7 @@ int sel_src_addr(struct iface_data *idata){
 							idata->ether_flag= cif->ether_f;
 							idata->ifindex= idata->nhifindex;
 							idata->flags= cif->flags;
-							strncpy(idata->iface, idata->nhiface, IFACE_LENGTH-1);
+							strncpy(idata->iface, idata->nhiface, IFACE_LENGTH);
 
 							if((cif->ip6_local).nprefix){
 								idata->ip6_local= (cif->ip6_local).prefix[0]->ip6;


### PR DESCRIPTION
The len parameter for strncpy() must include the null-terminating
byte. If not, the string may end up without its null terminator.

This should fix bug #63 [1]. The behavior of the tools after this
fix is not tested.

[1] https://github.com/fgont/ipv6toolkit/issues/63