### PR TITLE
Remove an uninitialized variable warning

### DIFF
--- a/tools/addr6.c
+++ b/tools/addr6.c
@@ -173,6 +173,9 @@ int main(int argc, char **argv){
 						puts("Prefix length error in IPv6 Source Address");
 						exit(EXIT_FAILURE);
 					}
+				} else {
+					puts("Missing Prefix Length");
+					exit(EXIT_FAILURE);
 				}
 
 				if(gettimeofday(&time, NULL) == -1){


### PR DESCRIPTION
This patch fixes the following warning, detected by GCC:

```
$ make clean; CFLAGS=-O2 make addr6
rm -f addr6 blackhole6 flow6 frag6 icmp6 jumbo6 mldq6 na6 ni6 ns6 path6 ra6 rd6 rs6 scan6 script6 tcp6 udp6 libipv6.o
rm -f data/ipv6toolkit.conf
[... other warnings removed ...]
gcc  -O2 -Wall -Wno-address-of-packed-member -Wno-missing-braces -c -o libipv6.o tools/libipv6.c
tools/addr6.c:185:5: warning: ‘genpref’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  185 |     randomize_ipv6_addr(&randaddr, &genaddr, genpref);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```