### PR TITLE
Sign compare

### DIFF
--- a/tools/addr6.c
+++ b/tools/addr6.c
@@ -80,11 +80,11 @@ int main(int argc, char **argv){
 	unsigned char		accepted_f=FALSE, acceptfilters_f=FALSE, duplicate_f=FALSE, flag_f=FALSE;
 
 	/* Block Filters */
-	struct in6_addr 	block[MAX_BLOCK], *ptable;
+	struct in6_addr 	block[MAX_BLOCK], *ptable = NULL;
 	struct in6_addr		genaddr, randaddr;
-	uint8_t				genpref;
+	uint8_t				genpref = 0;
 	
-	uint32_t			*pcounter, pthres, pratio;
+	uint32_t			*pcounter = NULL, pthres, pratio;
 	uint8_t				blocklen[MAX_BLOCK];
 	unsigned int		nblock=0;
 

--- a/tools/flow6.c
+++ b/tools/flow6.c
@@ -103,7 +103,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -727,7 +727,7 @@ int send_fid_probe(void){
 
 	if(nw != (ptr- buffer)){
 		if(idata.verbose_f)
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 
 		return(-1);
 	}

--- a/tools/frag6.c
+++ b/tools/frag6.c
@@ -115,7 +115,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -1887,7 +1887,7 @@ int send_fragment2(struct iface_data *idata, uint16_t ip6len, unsigned int id, u
 	}
 
 	if(nw != (ptr- buffer)){
-		printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+		printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n",  nw, (LUI) (ptr-buffer));
 		return(-1);
 	}
 
@@ -2124,7 +2124,7 @@ int send_fragment(struct iface_data *idata, unsigned int id, unsigned int offset
 	}
 
 	if(nw != (ptr- buffer)){
-		printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+		printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 		return(-1);
 	}
 
@@ -2253,8 +2253,8 @@ int send_fid_probe(struct iface_data *idata){
 		}
 
 		if(nw != (fptr- fragbuffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-												(LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+												nw, (LUI) (ptr-buffer));
 			return(-1);
 		}
 	} /* Sending fragments */

--- a/tools/icmp6.c
+++ b/tools/icmp6.c
@@ -129,7 +129,7 @@ struct dlt_null		*dlt_null;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -1744,7 +1744,7 @@ void send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pk
 				}
 
 				if(nw != (ptr-buffer)){
-					printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+					printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 												(LUI) (ptr-buffer));
 					exit(EXIT_FAILURE);
 				}
@@ -1802,8 +1802,8 @@ void send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pk
 					}
 
 					if(nw != (fptr- fragbuffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-												(LUI) nw, (LUI) (ptr-buffer));
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+												nw, (LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}
 				} /* Sending fragments */

--- a/tools/jumbo6.c
+++ b/tools/jumbo6.c
@@ -99,7 +99,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -906,8 +906,8 @@ int send_packet(struct iface_data *idata, struct pcap_pkthdr *pkthdr, const u_ch
 		}
 
 		if(nw != (ptr-buffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-						(LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+						nw, (LUI) (ptr-buffer));
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -978,8 +978,8 @@ int send_packet(struct iface_data *idata, struct pcap_pkthdr *pkthdr, const u_ch
 			}
 
 			if(nw != (fptr- fragbuffer)){
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-														(LUI) nw, (LUI) (ptr-buffer));
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+														nw, (LUI) (ptr-buffer));
 				exit(EXIT_FAILURE);
 			}
 		} /* Sending fragments */

--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -637,7 +637,7 @@ int find_ipv6_router_full(pcap_t *pfd, struct iface_data *idata){
 	unsigned char				*prev_nh;
 	volatile unsigned char		*ptr;
 	volatile unsigned char		*p;
-	size_t						nw;
+	int 						nw;
 
 	unsigned char				buffer[65556];
 	unsigned int 				rs_max_packet_size;
@@ -765,7 +765,7 @@ int find_ipv6_router_full(pcap_t *pfd, struct iface_data *idata){
 
 		if(nw != (ptr-buffer)){
 			if(idata->verbose_f>1)
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 												(LUI) (ptr-buffer));
 
 			error_f=1;
@@ -1135,7 +1135,7 @@ int ipv6_to_ether(pcap_t *pfd, struct iface_data *idata, struct in6_addr *target
 	struct sigaction			new_sig, old_sig;
 	int							result;
 	unsigned char				error_f=0;
-	size_t						nw;
+	int 						nw;
 
 	ns_max_packet_size = idata->mtu;
 
@@ -1238,7 +1238,7 @@ int ipv6_to_ether(pcap_t *pfd, struct iface_data *idata, struct in6_addr *target
 
 		if(nw != (ptr-buffer)){
 			if(idata->verbose_f>1)
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 												(LUI) (ptr-buffer));
 			error_f=1;
 			break;
@@ -1993,7 +1993,7 @@ struct in6_addr *sel_src_addr_ra(struct iface_data *idata, struct in6_addr *dst)
 
 int send_neighbor_advert(struct iface_data *idata, pcap_t *pfd,  const u_char *pktdata){
 	unsigned int				i;
-	size_t						nw;
+	int 						nw;
 	struct ether_header			*pkt_ether;
 	struct ip6_hdr				*pkt_ipv6;
 	struct nd_neighbor_solicit	*pkt_ns;
@@ -2139,8 +2139,8 @@ int send_neighbor_advert(struct iface_data *idata, pcap_t *pfd,  const u_char *p
 
 	if(nw != (ptr-wbuffer)){
 		if(idata->verbose_f)
-			printf("send_neighbor_advert(): pcap_inject(): only wrote %lu bytes "
-							"(rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-wbuffer));
+			printf("send_neighbor_advert(): pcap_inject(): only wrote %d bytes "
+							"(rather than %lu bytes)\n", nw, (LUI) (ptr-wbuffer));
 
 		return(-1);
 	}
@@ -2520,7 +2520,7 @@ int send_neighbor_solicit(struct iface_data *idata, struct in6_addr *target){
 	unsigned int 			ns_max_packet_size;
 	struct ether_header		*ether;
 	unsigned char 			*v6buffer;
-	size_t					nw;
+	int 					nw;
 	struct ip6_hdr			*ipv6;
 	struct nd_neighbor_solicit	*ns;
 	struct nd_opt_slla		*sllaopt;
@@ -2588,7 +2588,7 @@ int send_neighbor_solicit(struct iface_data *idata, struct in6_addr *target){
 
 	if(nw != (ptr-buffer)){
 		if(idata->verbose_f > 1)
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 											(LUI) (ptr-buffer));
 		return(-1);
 	}
@@ -4314,7 +4314,7 @@ int find_ipv6_router(pcap_t *pfd, struct ether_addr *hsrcaddr, struct in6_addr *
 	unsigned char				*pkt_end;
 	unsigned char				*ptr, *prev_nh;
 	int							r;
-	size_t						nw;
+	int 						nw;
 
 	unsigned char				buffer[65556];
 	unsigned int 				rs_max_packet_size;
@@ -4422,7 +4422,7 @@ int find_ipv6_router(pcap_t *pfd, struct ether_addr *hsrcaddr, struct in6_addr *
 		}
 
 		if(nw != (ptr-buffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																			(LUI) (ptr-buffer));
 			return(-1);
 		}

--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -3557,7 +3557,7 @@ int sel_src_addr(struct iface_data *idata){
 							idata->ether_flag= cif->ether_f;
 							idata->ifindex= idata->nhifindex;
 							idata->flags= cif->flags;
-							strncpy(idata->iface, idata->nhiface, IFACE_LENGTH-1);
+							strncpy(idata->iface, idata->nhiface, IFACE_LENGTH);
 
 							if((cif->ip6_local).nprefix){
 								idata->ip6_local= (cif->ip6_local).prefix[0]->ip6;

--- a/tools/mldq6.c
+++ b/tools/mldq6.c
@@ -71,7 +71,7 @@ struct ether_header		*ethernet, *pkt_ether;
 struct nd_opt_slla		*sllaopt;
 char					*lasts, *endptr;
     
-size_t					nw;
+int 					nw;
 unsigned long			ul_res, ul_val;
     
 unsigned int			i, j, sources, nsources, startrand;
@@ -815,7 +815,7 @@ void send_packet(struct iface_data *idata){
 				}
     
 				if(nw != (ptr-buffer)){
-					printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+					printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																				(LUI) (ptr-buffer));
 					exit(EXIT_FAILURE);
 				}
@@ -873,7 +873,7 @@ void send_packet(struct iface_data *idata){
 					}
 
 					if(nw != (fptr- fragbuffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw,\
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw,\
 																				(LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}

--- a/tools/na6.c
+++ b/tools/na6.c
@@ -82,7 +82,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *pref, *rpref, *endptr;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -1402,7 +1402,7 @@ int send_packet(struct iface_data *idata, struct pcap_pkthdr *pkthdr, const u_ch
 					}
 
 					if(nw != (ptr-buffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																					(LUI) (ptr-buffer));
 						return(FAILURE);
 					}
@@ -1459,8 +1459,8 @@ int send_packet(struct iface_data *idata, struct pcap_pkthdr *pkthdr, const u_ch
 						}
 
 						if(nw != (fptr- fragbuffer)){
-							printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n"\
-													, (LUI) nw, (LUI) (ptr-buffer));
+							printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n"\
+													, nw, (LUI) (ptr-buffer));
 							return(FAILURE);
 						}
 					}

--- a/tools/ni6.c
+++ b/tools/ni6.c
@@ -106,7 +106,7 @@ struct ether_header	*ethernet;
 char				*lasts, *rpref;
 char				*charptr, *printname, *printnamed;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -2234,7 +2234,7 @@ int send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pkt
 
 		if(nw != (ptr-buffer)){
 			if(idata->verbose_f)
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 
 			return(-1);
 		}
@@ -2296,7 +2296,7 @@ int send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pkt
 
 			if(nw != (fptr- fragbuffer)){
 				if(idata->verbose_f)
-					printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+					printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 
 				return(-1);
 			}

--- a/tools/ni6.c
+++ b/tools/ni6.c
@@ -2546,9 +2546,11 @@ void print_attack_info(struct iface_data *idata){
 		switch(qtype){
 			case 0:
 				puts(", NOOP (Qtype 0)");
+				break;
 
 			case 1:
 				puts(", Supported Qtypes (Qtype 1)");
+				break;
 
 			case 2:
 				printf(", Data is a Name (Qtype %u)\n", qtype);

--- a/tools/ns6.c
+++ b/tools/ns6.c
@@ -79,7 +79,7 @@ struct nd_opt_slla	*sllaopt;
 struct in6_addr		targetaddr, *pkt_ipv6addr; ;
 char				*lasts, *endptr;
     
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
     
 unsigned int		i, j, startrand, sources, nsources, targets, ntargets;
@@ -1305,7 +1305,7 @@ void send_packet(struct iface_data *idata){
 					}
     
 					if(nw != (ptr-buffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																						(LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}
@@ -1362,7 +1362,7 @@ void send_packet(struct iface_data *idata){
 						}
     
 						if(nw != (fptr- fragbuffer)){
-							printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+							printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																					(LUI) (ptr-buffer));
 							exit(EXIT_FAILURE);
 						}
@@ -1511,7 +1511,7 @@ int send_packet_to_ns(struct iface_data *idata, struct pcap_pkthdr *pkthdr, cons
 					}
 
 					if(nw != (ptr-buffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																					(LUI) (ptr-buffer));
 						return(FAILURE);
 					}
@@ -1568,8 +1568,8 @@ int send_packet_to_ns(struct iface_data *idata, struct pcap_pkthdr *pkthdr, cons
 						}
 
 						if(nw != (fptr- fragbuffer)){
-							printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n"\
-													, (LUI) nw, (LUI) (ptr-buffer));
+							printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n"\
+													, nw, (LUI) (ptr-buffer));
 							return(FAILURE);
 						}
 					}

--- a/tools/path6.c
+++ b/tools/path6.c
@@ -109,7 +109,7 @@ struct nd_opt_tlla	*tllaopt;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -1720,8 +1720,8 @@ int send_probe(struct iface_data *idata, unsigned int probetype, unsigned char c
 		}
 
 		if(nw != (ptr-buffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-						(LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+						nw, (LUI) (ptr-buffer));
 			return(-1);
 		}
 
@@ -1780,8 +1780,8 @@ int send_probe(struct iface_data *idata, unsigned int probetype, unsigned char c
 			}
 
 			if(nw != (fptr- fragbuffer)){
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-								(LUI) nw, (LUI) (ptr-buffer));
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+								nw, (LUI) (ptr-buffer));
 				exit(EXIT_FAILURE);
 			}
 		} /* Sending fragments */

--- a/tools/ra6.c
+++ b/tools/ra6.c
@@ -85,7 +85,7 @@ struct nd_opt_route_info_l	*routeopt;
 
 char						*lasts, *rpref, *endptr;
     
-size_t						nw;
+int 						nw;
 uint16_t					lifetime;
 uint32_t					reachable;
 uint32_t					retrans;
@@ -1807,7 +1807,7 @@ void send_packet(struct iface_data *idata, const u_char *pktdata){
 				}
 		
 				if(nw != (ptr-buffer)){
-					printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+					printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 					exit(EXIT_FAILURE);
 				}
 			}
@@ -1863,7 +1863,7 @@ void send_packet(struct iface_data *idata, const u_char *pktdata){
 					}
 			
 					if(nw != (fptr- fragbuffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, (LUI) (ptr-buffer));
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, (LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}
 				}	

--- a/tools/rd6.c
+++ b/tools/rd6.c
@@ -121,7 +121,7 @@ unsigned int			nlinkaddr=0, linkaddrs;
 
 char					*lasts, *rpref;
 char					*charptr;
-size_t					nw;
+int 					nw;
 unsigned long			ul_res, ul_val;
 unsigned int			i, j, startrand;
 unsigned int			skip;
@@ -1817,7 +1817,7 @@ void send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pk
 					}
 
 					if(nw != (ptr-buffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 													(LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}
@@ -1874,8 +1874,8 @@ void send_packet(struct iface_data *idata, const u_char *pktdata, struct pcap_pk
 						}
 
 						if(nw != (fptr- fragbuffer)){
-							printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-																(LUI) nw, (LUI) (ptr-buffer));
+							printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+																nw, (LUI) (ptr-buffer));
 							exit(EXIT_FAILURE);
 						}
 					} /* Sending fragments */

--- a/tools/rs6.c
+++ b/tools/rs6.c
@@ -72,7 +72,7 @@ struct ether_header		*ethernet, *pkt_ether;
 struct nd_opt_slla		*sllaopt;
 char					*lasts, *endptr;
     
-size_t					nw;
+int 					nw;
 unsigned long			ul_res, ul_val;
     
 unsigned int			i, j, sources, nsources, startrand;
@@ -752,7 +752,7 @@ void send_packet(struct iface_data *idata){
 				}
     
 				if(nw != (ptr-buffer)){
-					printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+					printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																				(LUI) (ptr-buffer));
 					exit(EXIT_FAILURE);
 				}
@@ -810,7 +810,7 @@ void send_packet(struct iface_data *idata){
 					}
 
 					if(nw != (fptr- fragbuffer)){
-						printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw,\
+						printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw,\
 																				(LUI) (ptr-buffer));
 						exit(EXIT_FAILURE);
 					}

--- a/tools/scan6.c
+++ b/tools/scan6.c
@@ -169,7 +169,7 @@ unsigned int			ndst=0;
 char					*lasts, *rpref;
 char					*charptr;
 
-size_t					nw;
+int 					nw;
 unsigned long			ul_res, ul_val;
 unsigned int			i, j, startrand;
 unsigned int			skip;
@@ -4573,7 +4573,7 @@ puts("In send_probe_remote(), after to send");
 
 	if(nw != (ptr-buffer)){
 		if(idata->verbose_f)
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																			(LUI) (ptr-buffer));
 		return(0);
 	}
@@ -4781,7 +4781,7 @@ int send_pscan_probe(struct iface_data *idata, struct scan_list *scan, struct po
 
 	if(nw != (ptr-buffer)){
 		if(idata->verbose_f)
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																			(LUI) (ptr-buffer));
 		return(0);
 	}
@@ -4989,7 +4989,7 @@ int multi_scan_local(pcap_t *pfd, struct iface_data *idata, struct in6_addr *src
 
 		if(nw != (ptr-buffer)){
 			if(idata->verbose_f>1)
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																			(LUI) (ptr-buffer));
 
 			error_f=TRUE;
@@ -5307,7 +5307,7 @@ int host_scan_local(pcap_t *pfd, struct iface_data *idata, struct in6_addr *srca
 
 		if(nw != (ptr-buffer)){
 			if(idata->verbose_f>1)
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", (LUI) nw, \
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", nw, \
 																		(LUI) (ptr-buffer));
 
 			error_f=TRUE;

--- a/tools/tcp6.c
+++ b/tools/tcp6.c
@@ -139,7 +139,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val, rate;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -2205,8 +2205,8 @@ void frag_and_send(struct iface_data *idata){
 		}
 
 		if(nw != (ptr-buffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-						(LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+						nw, (LUI) (ptr-buffer));
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -2263,8 +2263,8 @@ void frag_and_send(struct iface_data *idata){
 			}
 
 			if(nw != (fptr- fragbuffer)){
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-								(LUI) nw, (LUI) (ptr-buffer));
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+								nw, (LUI) (ptr-buffer));
 				exit(EXIT_FAILURE);
 			}
 		} /* Sending fragments */

--- a/tools/udp6.c
+++ b/tools/udp6.c
@@ -122,7 +122,7 @@ unsigned int		nlinkaddr=0, linkaddrs;
 char				*lasts, *rpref;
 char				*charptr;
 
-size_t				nw;
+int 				nw;
 unsigned long		ul_res, ul_val, rate;
 unsigned int		i, j, startrand;
 unsigned int		skip;
@@ -1693,8 +1693,8 @@ void frag_and_send(struct iface_data *idata){
 		}
 
 		if(nw != (ptr-buffer)){
-			printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-						(LUI) nw, (LUI) (ptr-buffer));
+			printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+						nw, (LUI) (ptr-buffer));
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -1750,8 +1750,8 @@ void frag_and_send(struct iface_data *idata){
 			}
 
 			if(nw != (fptr- fragbuffer)){
-				printf("pcap_inject(): only wrote %lu bytes (rather than %lu bytes)\n", \
-								(LUI) nw, (LUI) (ptr-buffer));
+				printf("pcap_inject(): only wrote %d bytes (rather than %lu bytes)\n", \
+								nw, (LUI) (ptr-buffer));
 				exit(EXIT_FAILURE);
 			}
 		} /* Sending fragments */


### PR DESCRIPTION
`GCC -Wextra` throws some "sign-compare" warnings. These are comparisons that are made between signed and unsigned data types. Because C does some implicit data type promotions when doing numeric comparisons and these promotions may not always result as expected, especially among different architectures, GCC issues a warning when it finds them.

In any case, it's a way to help clean the code from compiler warnings.

In this PR I send the first commit related to fixing this issue. More to come, but I wanted to start with low-hanging fruit first:

```
Change all size_t nw to int to fix -Wsign-compare

nw is declared as size_t but it is used to receive the result from
pcap_inject which is defined as int, as the return code in an error
situation is -1.
```

`nw` is only used to handle `pcap_inject()` errors, so not much harm (if any) should occur with this patch.

Other fixes might require more thorough review, so let's start with these first.

Best regards,
Octavio.