### PR TITLE
ra6: fix incomplete copy/paste

### DIFF
--- a/tools/ra6.c
+++ b/tools/ra6.c
@@ -458,7 +458,7 @@ int main(int argc, char **argv){
 				idata.hdstaddr_f = 1;
 		
 				if(ether_pton(optarg, &(idata.hdstaddr), sizeof(idata.hdstaddr)) == 0){
-					puts("Error in Source link-layer address.");
+					puts("Error in Destination link-layer address.");
 					exit(EXIT_FAILURE);
 				}
 				break;


### PR DESCRIPTION
Code was copied from -S to -D but forgot to change "Source" to "Destination".