### PR TITLE
ra6: Fix documentation of "-r"

### DIFF
--- a/manuals/ra6.1
+++ b/manuals/ra6.1
@@ -75,7 +75,7 @@ This option specifies the Router Lifetime value that is included in Router Adver
 .TP
 \-\-reachable, \-r
 
-This option specifies the Reachable Time value that is included in Router Advertisement messages. The Router Lifetime is the amount of time in milliseconds that a neighbor is considered "reachable" after a reachability confirmation. If this option is left unspecified, a Reachable Time of 0xffffffff ("infinity") is selected.
+This option specifies the Reachable Time value that is included in Router Advertisement messages. The Reachable Time is the amount of time in milliseconds that a neighbor is considered "reachable" after a reachability confirmation. If this option is left unspecified, a Reachable Time of 0xffffffff ("infinity") is selected.
 
 .TP
 \-\-retrans, \-x


### PR DESCRIPTION
This option is used to specify the Reachable Time but the paragraph
where it is explained falsely used the term "Router Lifetime".