### PR TITLE
Address bug in addr6

### DIFF
--- a/tools/addr6.c
+++ b/tools/addr6.c
@@ -1810,8 +1810,8 @@ void print_stats(struct stats6 *stats) {
                ((float)(stats->iidembeddedipv4_32) / totaliids) * 100, stats->iidembeddedipv4_64,
                ((float)(stats->iidembeddedipv4_64) / totaliids) * 100);
 
-        printf("Embed-port: %11lu (%6.2f%%)\tEmbed-port (r):  %11lu (%6.2f%%)\n", stats->iidembeddedport,
-               ((float)(stats->iidembeddedport) / totaliids) * 100, stats->iidembeddedportrev,
+        printf("Embed-port: %11lu (%6.2f%%)\tEmbed-port (r):  %11lu (%6.2f%%)\n", stats->iidembeddedportfwd,
+               ((float)(stats->iidembeddedportfwd) / totaliids) * 100, stats->iidembeddedportrev,
                ((float)(stats->iidembeddedportrev) / totaliids) * 100);
 
         printf("ISATAP:     %11lu (%6.2f%%)\tTeredo:          %11lu (%6.2f%%)\n", stats->iidisatap,

--- a/tools/libipv6.c
+++ b/tools/libipv6.c
@@ -284,20 +284,20 @@ void decode_ipv6_address(struct decode6 *addr) {
             /* We assume the u bit can be 0 o 1, but the i/g bit must be 0 */
             addr->iidtype = IID_ISATAP;
         }
-        else if (addr->ip6.s6_addr32[2] == 0 && (addr->ip6.s6_addr32[3] & htonl(0xff000000)) != 0 &&
-                 (ntohl(addr->ip6.s6_addr32[3]) & 0x0000ffff) != 0) {
-            addr->iidtype = IID_EMBEDDEDIPV4;
-            addr->iidsubtype = IID_EMBEDDEDIPV4_32;
-        }
-        else if (addr->ip6.s6_addr32[2] == 0 && ((addr->ip6.s6_addr32[3] & htonl(0xff000000)) == 0 &&
+        else if (addr->ip6.s6_addr32[2] == 0 && ((ntohl(addr->ip6.s6_addr32[3]) >> 16) <= 16 &&
                                                  is_service_port(ntohl(addr->ip6.s6_addr32[3]) & 0x0000ffff))) {
             addr->iidtype = IID_EMBEDDEDPORT;
             addr->iidsubtype = IID_EMBEDDEDPORT;
         }
-        else if (addr->ip6.s6_addr32[2] == 0 && ((addr->ip6.s6_addr32[3] & htonl(0x0000ff00)) == 0 &&
+        else if (addr->ip6.s6_addr32[2] == 0 && ((ntohl(addr->ip6.s6_addr32[3]) & 0x0000ffff) <= 16 &&
                                                  is_service_port(ntohl(addr->ip6.s6_addr32[3]) >> 16))) {
             addr->iidtype = IID_EMBEDDEDPORT;
             addr->iidsubtype = IID_EMBEDDEDPORTREV;
+        }
+        else if ((ntohl(addr->ip6.s6_addr32[2])) == 0 && ((ntohl(addr->ip6.s6_addr32[3])) & 0xff000000) != 0 &&
+                 (ntohl(addr->ip6.s6_addr32[3]) & 0x0000ffff) != 0) {
+            addr->iidtype = IID_EMBEDDEDIPV4;
+            addr->iidsubtype = IID_EMBEDDEDIPV4_32;
         }
         else if (addr->ip6.s6_addr32[2] == 0 && (addr->ip6.s6_addr32[3] & htonl(0xff000000)) == 0 &&
                  (ntohl(addr->ip6.s6_addr32[3]) & 0x0000ffff) != 0) {


### PR DESCRIPTION
Address the bug reported in https://github.com/fgont/ipv6toolkit/issues/81 .

Additionally, narrow down the cases to infer embed-port addresses, and prioritize embed-port addresses over embed-ipv4.