### PR TITLE
Streamline workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,10 +15,7 @@ on:
   push:
     branches:
     - '**'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-    - '**'
+
   schedule:
     - cron: '20 16 * * 3'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - '**'
-  pull_request:
-    branches:
-    - '**'
 
 jobs:
   UbuntuLatest:


### PR DESCRIPTION
Only run them on push, and not PR. -- otherwise they get run multiple times unnecessarily